### PR TITLE
Fixed a typo (maybe?) in the path of `spikes.ckpt`

### DIFF
--- a/ch02_basics/Concept06_saving_variables.ipynb
+++ b/ch02_basics/Concept06_saving_variables.ipynb
@@ -127,7 +127,7 @@
     }
    ],
    "source": [
-    "save_path = saver.save(sess, \"spikes.ckpt\")\n",
+    "save_path = saver.save(sess, \"./spikes.ckpt\")\n",
     "print(\"spikes data saved in file: %s\" % save_path)"
    ]
   },


### PR DESCRIPTION
A ValueError will be raised if we don't have './' in front of the file (at least on MacOS), saying:

ValueError: Parent directory of spikes.ckpt doesn't exist, can't save.